### PR TITLE
Changed builder signature to accept ActionContext.

### DIFF
--- a/Payment.Processor/Builders/CardOnFileContextBuilder.cs
+++ b/Payment.Processor/Builders/CardOnFileContextBuilder.cs
@@ -9,7 +9,7 @@ namespace Payment.Processor.Builders
     {
         public CardOnFileContextBuilder() { }
 
-        public CardOnFileContext Build<TContext>(ITransactionModel transaction, IActionContext actionContext)
+        public CardOnFileContext Build(ITransactionModel transaction, IActionContext actionContext)
         {
             var metadata = transaction.Details.Metadata;
             var sequenceIndicator = SequenceIndicator(transaction);

--- a/Payment.Processor/Builders/IBuilder.cs
+++ b/Payment.Processor/Builders/IBuilder.cs
@@ -5,9 +5,8 @@ namespace Payment.Processor.Builders
 {
     public interface IBuilder<T>
     {
-        // TODO: should T be nullable?
         T Build(ITransactionModel transaction) => throw new NotImplementedException();
-        T Build<TContext>(ITransactionModel transaction, IContext context) where TContext : class
+        T Build(ITransactionModel transaction, IActionContext context)
             => throw new NotImplementedException();
     }
 }

--- a/Payment.Workflow/WorkflowTaskAsync.cs
+++ b/Payment.Workflow/WorkflowTaskAsync.cs
@@ -11,8 +11,6 @@ namespace Payment.Workflow
             this.workflowContext = workflowContext;
         }
 
-        //public IWorkflowContext WorkflowContext { get; init; }
-
         public async Task<bool> RunAsync()
         {
             if (workflowContext.WorkflowState)

--- a/TSYSProcessor/Processor/TransactionTasks/BuildTransactionContext.cs
+++ b/TSYSProcessor/Processor/TransactionTasks/BuildTransactionContext.cs
@@ -35,17 +35,21 @@ namespace TsysProcessor.Processor.TransactionSteps
                 throw new ArgumentNullException("Transaction");
 
             var actionContext = actionContextBuilder.Build(transaction);
+            var cardContext = await cardContextBuilder.BuildAsync(transaction);
+            var cardOnFileContext = cardOnFileContextBuilder.Build(transaction, actionContext);
+            var envelope = envelopeBuilder.Build(transaction);
+            var readerContext = readerContextBuilder.Build(transaction);
 
             var transactionContext = new TsysTransactionContext()
             {
                 ActionContext = actionContext,
-                CardContext = await cardContextBuilder.BuildAsync(transaction),
-                CardOnFileContext = cardOnFileContextBuilder.Build<CardOnFileContext>(transaction, actionContext),
+                CardContext = cardContext,
+                CardOnFileContext = cardOnFileContext,
                 Details = transaction.Details,
-                Envelope = envelopeBuilder.Build(transaction),
+                Envelope = envelope,
                 Merchant = transaction.Merchant,
                 ProcessorAttributes = transaction.ProcessorAttributes,
-                ReaderContext = readerContextBuilder.Build(transaction)
+                ReaderContext = readerContext
             };
 
             WorkflowContext.TransactionContext = transactionContext;

--- a/TSYSProcessor/Processor/TransactionTasks/TsysTaskAsync.cs
+++ b/TSYSProcessor/Processor/TransactionTasks/TsysTaskAsync.cs
@@ -5,7 +5,7 @@ namespace TsysProcessor.Processor.TransactionTasks
 {
     public abstract class TsysTaskAsync : WorkflowTaskAsync<TsysWorkflowContext>
     {
-        protected TsysTaskAsync(TsysWorkflowContext workflowContext) : base(workflowContext)
+        public TsysTaskAsync(TsysWorkflowContext workflowContext) : base(workflowContext)
         {
         }
     }

--- a/Tests.Payment.Processor/Builders/CardOnFileContextBuilderTests.cs
+++ b/Tests.Payment.Processor/Builders/CardOnFileContextBuilderTests.cs
@@ -23,7 +23,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(isReturn, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.CardOnFile.Should().Be(expectedValue);
         }
 
@@ -36,7 +36,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.FirstPayment.Should().Be(expectedValue);
         }
 
@@ -49,7 +49,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.InstallmentPayment.Should().Be(expectedValue);
         }
 
@@ -62,7 +62,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.MerchantInitiated.Should().Be(expectedValue);
         }
 
@@ -76,7 +76,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.MultipartPayment.Should().Be(expectedValue);
         }
 
@@ -90,7 +90,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.OneTimePayment.Should().Be(expectedValue);
         }
 
@@ -104,7 +104,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.PaymentPlanId.Should().Be(expectedValue);
         }
 
@@ -118,7 +118,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.Platform.Should().Be(expectedValue);
         }
 
@@ -132,7 +132,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.RecurringPayment.Should().Be(expectedValue);
         }
 
@@ -147,7 +147,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.SaveCard.Should().Be(expectedValue);
         }
 
@@ -161,7 +161,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.ScheduledPayment.Should().Be(expectedValue);
         }
 
@@ -175,7 +175,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.SequenceIndicator.Should().Be(expectedValue);
         }
 
@@ -189,7 +189,7 @@ namespace Tests.Payment.Processor.Builders
             var transaction = SetupTransaction(paymentPlanType, paymentNumber, cardState);
             var actionContext = SetupActionContext(false, cardState);
             var testBuilder = new CardOnFileContextBuilder();
-            var testContext = testBuilder.Build<ActionContext>(transaction, actionContext.Object);
+            var testContext = testBuilder.Build(transaction, actionContext.Object);
             testContext.TotalPaymentCount.Should().Be(expectedValue);
         }
 


### PR DESCRIPTION
No need for a generic context in the builder.